### PR TITLE
Fix/fix request timeout

### DIFF
--- a/pysimplesoap/transport.py
+++ b/pysimplesoap/transport.py
@@ -14,6 +14,7 @@
 
 
 import logging
+import socket
 import ssl
 import sys
 from distutils.version import LooseVersion
@@ -93,9 +94,8 @@ else:
                 kwargs['proxy_info'] = httplib2.ProxyInfo(proxy_type=socks.PROXY_TYPE_HTTP, **proxy)
                 log.info("using proxy %s" % proxy)
 
+            kwargs['timeout'] = timeout 
             # set optional parameters according to supported httplib2 version
-            if LooseVersion(httplib2.__version__) >= LooseVersion('0.3.0'):
-                kwargs['timeout'] = timeout
             if LooseVersion(httplib2.__version__) >= LooseVersion('0.7.0'):
                 kwargs['disable_ssl_certificate_validation'] = cacert is None
                 kwargs['ca_certs'] = cacert

--- a/pysimplesoap/transport.py
+++ b/pysimplesoap/transport.py
@@ -14,7 +14,6 @@
 
 
 import logging
-import socket
 import ssl
 import sys
 from distutils.version import LooseVersion

--- a/tests/timeout_httplib2_test.py
+++ b/tests/timeout_httplib2_test.py
@@ -1,0 +1,26 @@
+import socket
+import unittest
+
+from pysimplesoap.transport import Httplib2Transport
+
+
+class TestHttplib2TransportTransportTimeout(unittest.TestCase):
+    def setUp(self):
+        # url that delays 2 seconds before returning
+        self.url = "https://httpbin.org/delay/2"
+
+    def test_timeout(self):
+        transport = Httplib2Transport(timeout=1)
+
+        with self.assertRaises(socket.timeout):
+            transport.request(self.url)
+
+    def test_no_timeout(self):
+        transport = Httplib2Transport(timeout=None)
+
+        response, _ = transport.request(self.url)
+        self.assertEqual(response.status, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Since `httplib2`'s [latest version](https://github.com/httplib2/httplib2) is `0.22.0`. And the timeout is already supported since [version 0.9](https://github.com/httplib2/httplib2/releases/tag/0.9).
So, this [condition](https://github.com/pysimplesoap/pysimplesoap/blob/master/pysimplesoap/transport.py#L97-L98) will always evaluate as `False`:
```python
if LooseVersion(httplib2.__version__) >= LooseVersion('0.3.0'):
    kwargs['timeout'] = timeout
```
Hence, the timeout parameter will always be `None`.